### PR TITLE
run linkcheck in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         # Activate env and build docs
         eval "$(conda shell.bash hook)"
         conda activate ./env
+        make linkcheck
         make html
 
         git clone \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         if [ -s broken ]; then
           echo "BROKEN LINKS IDENTIFIED"
           cat broken
+          exit 1
         fi
 
     - name: build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,12 @@ jobs:
         # Activate env and build docs
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        make linkcheck
+        make linkcheck | tee linkcheck.log
+        grep -w "broken" linkcheck.log > broken
+        if [ -s broken ]; then
+          echo "BROKEN LINKS IDENTIFIED"
+          cat broken
+        fi
 
     - name: build docs
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,13 @@ jobs:
         # Activate env and build docs
         eval "$(conda shell.bash hook)"
         conda activate ./env
+
+        # check for broken links
         make linkcheck | tee linkcheck.log
-        grep -w "broken" linkcheck.log > broken
+
+        # Prevent completely exiting the test if pattern not found
+        grep -w "broken" linkcheck.log > broken ||  true
+
         if [ -s broken ]; then
           echo "BROKEN LINKS IDENTIFIED"
           cat broken

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         conda create -p ./env --file docs-requirements.txt --channel conda-forge
 
     - name: check links
+      run: |
         # Activate env and build docs
         eval "$(conda shell.bash hook)"
         conda activate ./env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,17 @@ jobs:
         eval "$(conda shell.bash hook)"
         conda create -p ./env --file docs-requirements.txt --channel conda-forge
 
+    - name: check links
+        # Activate env and build docs
+        eval "$(conda shell.bash hook)"
+        conda activate ./env
+        make linkcheck
+
     - name: build docs
       run: |
         # Activate env and build docs
         eval "$(conda shell.bash hook)"
         conda activate ./env
-        make linkcheck
         make html
 
         git clone \

--- a/source/conf.py
+++ b/source/conf.py
@@ -133,5 +133,5 @@ linkcheck_ignore = [
 
     # Scraping returns 500, but website seems fine. Possibly a timeout issue
     # since the site seems slow.
-    r'http://blogs.nature.com/methagora',
+    #r'http://blogs.nature.com/methagora',
 ]

--- a/source/conf.py
+++ b/source/conf.py
@@ -133,5 +133,5 @@ linkcheck_ignore = [
 
     # Scraping returns 500, but website seems fine. Possibly a timeout issue
     # since the site seems slow.
-    #r'http://blogs.nature.com/methagora',
+    r'http://blogs.nature.com/methagora',
 ]

--- a/source/conf.py
+++ b/source/conf.py
@@ -107,3 +107,9 @@ html_short_title = "Home"
 html_sidebars = {
     '**': ['localtoc.html', 'sourcelink.html', 'searchbox.html'],
 }
+
+linkcheck_request_headers = {
+    "https://ncbi.nlm.nih.gov": {
+        "User-Agent": "Mozilla",
+    }
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -109,7 +109,7 @@ html_sidebars = {
 }
 
 linkcheck_request_headers = {
-    "https://ncbi.nlm.nih.gov": {
-        "User-Agent": "Mozilla",
+    "*": {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     }
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -108,8 +108,30 @@ html_sidebars = {
     '**': ['localtoc.html', 'sourcelink.html', 'searchbox.html'],
 }
 
+# Running `make linkcheck` will ensure links are working. However, some sites
+# are resistant to scraping, so need some tweaks here:
 linkcheck_request_headers = {
+    # Add a user agent to everything
     "*": {
         "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     }
 }
+
+# Avoids downloading the entire page to check anchors.
+linkcheck_anchors = False
+
+# Completely ignore these regexes
+linkcheck_ignore = [
+    # Appears to be using CloudFlare, not worth the effor to spoof here
+    r'https://gatk.broadinstitute.org',
+
+    # Also scrape-resistant
+    r'https://twitter.com',
+
+    # SSL/TLS errors
+    r'https://www.sempf.net',
+
+    # Scraping returns 500, but website seems fine. Possibly a timeout issue
+    # since the site seems slow.
+    r'http://blogs.nature.com/methagora',
+]

--- a/source/gitlab.rst
+++ b/source/gitlab.rst
@@ -14,9 +14,6 @@ in the NICHD data center which is only accessible inside the NIH network. If
 you have access to the NIH network and you are interested in accessing this
 GitLab instance, contact ryan.dale@nih.gov for more info.
 
-If you already have access to our GitLab instance, you can find it at
-https://hdgitappip01.nichd.nih.gov (sign in with your NIH credentials).
-
 It's expected that you already know :ref:`git`.
 
 For the basics of GitLab, the `GitLab basics

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,6 +8,9 @@ topics.
 
   Note: the opinions on these pages do not reflect those of NICHD or NIH.
 
+There's a lot of excellent training material out there, so rather than repeat
+it, this website acts as a central location of curated resources. We've found
+the good stuff so you can get right to learning.
 
 Start here
 ----------
@@ -15,12 +18,9 @@ Start here
 Bioinformatics and scientific programming is a big field, and it can be
 difficult to know where to start.
 
-If possible, schedule a meeting (ryan.dale@nih.gov) to discuss your training
-goals and expectations so we can help develop a customized training plan.
-
-There's a lot of excellent training material out there, so rather than repeat
-it, this website acts as a central location of curated resources to help focus
-your learning.
+If you are at NIH, you can schedule a meeting (ryan.dale@nih.gov) to discuss
+your training goals and expectations so we can help develop a customized
+training plan.
 
 Ready? Head to :ref:`first-steps`.
 
@@ -32,11 +32,16 @@ If you haven't been here in a while and want to know what's new, see the :ref:`c
 Currently-written topics
 ------------------------
 
-:ref:`first-steps` gives you an introduction to the content here and some context.
-
+:ref:`first-steps` gives you an introduction to the content here and some
+context. If you're just starting out, head there first.
 
 Initial training
 ~~~~~~~~~~~~~~~~
+
+These sections help you learn the basics of programming, and include some
+examples of beginner/intermediate/advanced skills to help you figure out where
+you are in your learning and how to advance.
+
 .. toctree::
    :maxdepth: 1
 
@@ -45,11 +50,12 @@ Initial training
    choosing-r-python
    python
    r
-   genomics-formats
 
 
-Supplemental training
-~~~~~~~~~~~~~~~~~~~~~
+Next steps
+~~~~~~~~~~
+
+Once you have the basics of programming, these sections will broaden your skills.
 
 .. toctree::
    :maxdepth: 1
@@ -63,9 +69,12 @@ Supplemental training
 Genomics
 ~~~~~~~~
 
+These sections point to resources to learn about some specific genomics topics:
+
 .. toctree::
    :maxdepth: 1
 
+   genomics-formats
    variant-calling
    rnaseq
    chipseq

--- a/source/python.rst
+++ b/source/python.rst
@@ -27,7 +27,7 @@ you'll need to install things separately using ``conda install
 You may have heard about Jupyter notebooks. While they have their place in data
 science-type work, I do not think this is a good way to learn Python. `Here are
 some reasons why
-<https://docs.google.com/presentation/d/1n2RlMdmv1p25Xy5thJUhkKGvjtV-dkAIsUXP-AL4ffI/edit#slide=id.g362da58057_0_1>`_;
+<https://docs.google.com/presentation/d/1n2RlMdmv1p25Xy5thJUhkKGvjtV-dkAIsUXP-AL4ffI/>`_;
 they boil down to needing to mentally keep track of what cells have been run
 when to avoid strange and hard-to-track-down bugs.
 
@@ -125,7 +125,7 @@ than sprinkling ``print()`` statements throughout your code!
 
 There is a good intro to the debugging workflow at `SciPy lecture notes:
 debugging
-<https://scipy-lectures.org/advanced/debugging/index.html#debugging-workflow>`_,
+<https://scipy-lectures.org/advanced/debugging/index.html>`_,
 along with what to do when you can't use IPython.
 
 Learning pandas
@@ -313,7 +313,7 @@ above categories.
 - `A Visual Intro to NumPy <https://jalammar.github.io/visual-numpy/>`_ is
   useful if you're just starting to learn NumPy
 
-- `The SciPy Lectures <https://www.scipy-lectures.org/>`_
+- `The SciPy Lectures <https://scipy-lectures.org/>`_
   First chapter of Scientific Python lectures includes NumPy, matplotlib, and
   scipy basics. Subsequent chapters get fairly advanced.
 

--- a/source/r.rst
+++ b/source/r.rst
@@ -187,36 +187,17 @@ for bioinformatics and biology packages, and CRAN is for everything else.
 Bioconductor packages need to satisfy lots of documentation and testing
 criteria, so they are typically high-quality packages.
 
-- The `main Bioconductor page <https://www.bioconductor.org/>`_ has
-  installation instructions and links for exploring packages
-
-- `Bioconductor for everyone
-  <http://biocworkshops2019.bioconductor.org.s3-website-us-east-1.amazonaws.com/page/BiocIntro__RBiocForAll/>`_
-  starts from the basics of R and goes through using some common Bioconductor
-  packages. If you've gone through one of the basic tutorials above, much of
-  the first part will be a nice review.
-
-- The `2019 Bioconductor Conference materials
-  <http://biocworkshops2019.bioconductor.org.s3-website-us-east-1.amazonaws.com/>`_ cover lots of topics.
+The `main Bioconductor page <https://www.bioconductor.org/>`_ has installation
+instructions and links for exploring packages. Bioconductor is a vast resource
+though, so rather than try to learn it all in practice you'll typically find
+a package that does what you want and then read the vignette (a tutorial that
+comes with the package) to learn how to use it.
 
 scRNA-seq
 ~~~~~~~~~
 
 Recently, many people have been asking about R specifically so that they can
-learn how to work with scRNA-seq on their own. There are several major packages
-for scRNA-seq: `Seurat <https://satijalab.org/seurat/>`_, a `suite of
-Bioconductor packages <https://bioconductor.org/books/release/OSCA/>`_, and
-`scanpy <https://scanpy.readthedocs.io/en/stable/>`_. Seurat and Bioconductor are
-in R, scanpy is Python. They are broadly the same, but are in somewhat of an
-arms race so some new features or analyses may not be immediately available in
-all of them.
-
-If you don't otherwise have strong opinions, I'd suggest Seurat. It's
-commonly-used, updated frequently, well-written, and has good documentation. To
-learn Seurat, go through the introductory vignettes in the dropdown menu at the
-top of the `Seurat home page <https://satijalab.org/seurat/>`_. Run them on
-your own to get a feel for how long the steps take and to make sure everything
-is installed and working correctly.
+learn how to work with scRNA-seq on their own.
 
 .. note::
 
@@ -229,6 +210,28 @@ is installed and working correctly.
     Seurat effectively. See the "Beginner" section above for learning these
     skills.
 
+
+There are several major packages
+for scRNA-seq: `Seurat <https://satijalab.org/seurat/>`_, a `suite of
+Bioconductor packages <https://bioconductor.org/books/release/OSCA/>`_, and
+`scanpy <https://scanpy.readthedocs.io/en/stable/>`_. Seurat and Bioconductor are
+in R, scanpy is Python. They are broadly the same, but are in somewhat of an
+arms race so some new features or analyses may not be immediately available in
+all of them.
+
+The book `Orchestrating Single-Cell Analysis with Bioconductor
+<https://bioconductor.org/books/release/OSCA/>`_ is a fantastic, comprehensive
+resource that even goes through worked examples of published data. This uses
+the suite of tools in Bioconductor. Highly recommended.
+
+`Seurat <https://satijalab.org/seurat/>`_ is another popular package for
+scRNA-seq, and has a series of vignettes on the home page. There have been
+recent improvments to the normalization (scTransform v1 and v2), and these use
+somewhat different steps. The different vignettes therefore differ in the
+steps, and it can be a bit confusing. The `PBMC3k tutorial
+<https://satijalab.org/seurat/articles/pbmc3k_tutorial.html>`_ is the classic
+starting point, so working through this one will at least give you the context
+to work through other vignettes.
 
 Additional resources
 --------------------


### PR DESCRIPTION
This PR runs `make linkchecks` in the GH Actions. This command checks all URLs in the docs to confirm they're still live.

Looks like there are cases where sites (like GATK docs) are using CloudFlare, which gets pretty fancy with blocking automation (like what is being used here, in the requests package). So those links show up as broken, even though a browser works fine. And it looks like PubMed will return 403 unless you have a `User-Agent` header in the request. The fixes for these are in `conf.py`.